### PR TITLE
Add support for .gitkeep in the changelog folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ You can also run:
 ``` 
 This task appends every line from every file in the `pendingChangelogDir` folder to the
 `changelogFile` file. It uses the configuration specified in the `commit {...}` section. It also 
-removes every file in the `pendingChangelogDir`.
+removes every file in the `pendingChangelogDir`. To avoid removing the folder itself, we recommend
+putting a file named `.gitkeep.` in `pendingChangelogDir`.
 
 ## Configuration ⚙️
 

--- a/src/main/kotlin/com/doist/gradle/changelog/ChangelogProcessor.kt
+++ b/src/main/kotlin/com/doist/gradle/changelog/ChangelogProcessor.kt
@@ -38,7 +38,9 @@ internal class ChangelogProcessor(private val config: CommitConfig) {
     }
 
     fun removePendingEntries(file: File) {
-        file.listFiles()?.forEach { it.deleteRecursively() }
+        file.listFiles()
+            ?.filter { it.name != ".gitkeep" }
+            ?.forEach { it.deleteRecursively() }
     }
 
     private fun String.insertAtLine(text: String, line: Int): String {

--- a/src/main/kotlin/com/doist/gradle/changelog/Validator.kt
+++ b/src/main/kotlin/com/doist/gradle/changelog/Validator.kt
@@ -5,6 +5,9 @@ import java.io.File
 internal class Validator(private val rules: List<Rule>) {
     fun findInvalidEntriesIn(file: File): List<InvalidEntry> {
         val invalidChangelogEntries = mutableListOf<InvalidEntry>()
+
+        if (file.name == ".gitkeep") return invalidChangelogEntries
+
         file.readLines().forEachIndexed { index, line ->
             rules.forEach { rule ->
                 if (!rule.check(line)) {

--- a/src/test/kotlin/com/doist/gradle/changelog/ChangelogProcessorTest.kt
+++ b/src/test/kotlin/com/doist/gradle/changelog/ChangelogProcessorTest.kt
@@ -1,6 +1,7 @@
 package com.doist.gradle.changelog
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -46,5 +47,45 @@ class ChangelogProcessorTest {
 
         """.trimIndent()
         assertEquals(expectedChangelog, changelogFile.readText())
+    }
+
+    @Test
+    fun `don't remove gitkeep file`() {
+        val entry = testFolder.newFile("fix.something")
+        val keep = testFolder.newFile(".gitkeep")
+        entry.writeText("")
+        keep.writeText("")
+
+        val changelogProcessor = ChangelogProcessor(
+            CommitConfig(
+                prefix = "## 0.0.2",
+                postfix = "",
+                entryPrefix = "- ",
+                insertAtLine = 2
+            )
+        )
+
+        changelogProcessor.removePendingEntries(testFolder.root)
+
+        assertEquals(listOf(keep.name), testFolder.root.listFiles().map { it.name })
+    }
+
+    @Test
+    fun `gitkeep file doesn't exist`() {
+        val entry = testFolder.newFile("fix.something")
+        entry.writeText("")
+
+        val changelogProcessor = ChangelogProcessor(
+            CommitConfig(
+                prefix = "## 0.0.2",
+                postfix = "",
+                entryPrefix = "- ",
+                insertAtLine = 2
+            )
+        )
+
+        changelogProcessor.removePendingEntries(testFolder.root)
+
+        assertTrue(testFolder.root.listFiles().isEmpty())
     }
 }

--- a/src/test/kotlin/com/doist/gradle/changelog/ValidatorTest.kt
+++ b/src/test/kotlin/com/doist/gradle/changelog/ValidatorTest.kt
@@ -1,6 +1,7 @@
 package com.doist.gradle.changelog
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -27,8 +28,15 @@ class ValidatorTest {
 
         val result = validator.findInvalidEntriesIn(file)
 
+        assertEquals(2, result.size)
         assertEquals(Validator.InvalidEntry(file, 0, notTooLongRule), result[0])
         assertEquals(Validator.InvalidEntry(file, 1, noDotRule), result[1])
-        assertEquals(2, result.size)
+
+        val keep = testFolder.newFile(".gitkeep").apply {
+            writeText(" ")
+        }
+        val keepResult = validator.findInvalidEntriesIn(keep)
+
+        assertTrue(keepResult.isEmpty())
     }
 }


### PR DESCRIPTION
## 🚀 Description
This PR adds support to ignore the `.gitkeep` file in the changelog folder.

This consist of two aspects:
1. Skip deleting the `.gitkeep` file when removing entries
2. Skip validating the `.gitkeep` file since a rule might fail.

## 📄 Motivation and Context
This will allow easier adding of changelogs after they are cleaned up by the task. It will also avoid failures in other scripts when the changelog folder doesn't exist.

## 🧪 How Has This Been Tested?
There are some unit tests added to test this change.

## 📦 Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

The only reason this is a breaking change is because a `.gitkeep` file currently behaves as a normal changelog entry file.

## ✅ Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
