### PR TITLE
build: set better timeout

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -11,6 +11,7 @@ jobs:
   validation:
     name: Validation
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout latest code
         uses: actions/checkout@v2


### PR DESCRIPTION
Set missing timeouts to 60 to avoid using the default of 6 hours.

See https://github.com/Doist/Issues/issues/5259