### PR TITLE
Update dependencies and fix gradle 8 issue

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -19,6 +19,11 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
       - name: Cache Gradle Caches
         uses: actions/cache@v1
         with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,29 +19,22 @@ repositories {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 gradlePlugin {
+    website.set(PluginBundle.WEBSITE)
+    vcsUrl.set(PluginBundle.VCS)
+
     plugins {
         create(PluginCoordinates.ID) {
             id = PluginCoordinates.ID
             implementationClass = PluginCoordinates.IMPLEMENTATION_CLASS
             version = PluginCoordinates.VERSION
-        }
-    }
-}
-
-pluginBundle {
-    website = PluginBundle.WEBSITE
-    vcsUrl = PluginBundle.VCS
-    description = PluginBundle.DESCRIPTION
-    tags = PluginBundle.TAGS
-
-    plugins {
-        getByName(PluginCoordinates.ID) {
-            displayName = PluginBundle.DISPLAY_NAME
+            displayName = PluginCoordinates.DISPLAY_NAME
+            description = PluginCoordinates.DESCRIPTION
+            tags.set(PluginCoordinates.TAGS)
         }
     }
 }
@@ -108,8 +101,4 @@ tasks.register("preMerge") {
 
 tasks.named<Wrapper>("wrapper") {
     distributionType = Wrapper.DistributionType.ALL
-}
-
-kotlinDslPluginOptions {
-    experimentalWarning.set(false)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,12 @@ java {
     targetCompatibility = JavaVersion.VERSION_11
 }
 
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+}
+
 gradlePlugin {
     website.set(PluginBundle.WEBSITE)
     vcsUrl.set(PluginBundle.VCS)

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,7 +4,3 @@ plugins {
 repositories {
     jcenter()
 }
-
-kotlinDslPluginOptions {
-    experimentalWarning.set(false)
-}

--- a/buildSrc/src/main/java/Coordinates.kt
+++ b/buildSrc/src/main/java/Coordinates.kt
@@ -3,12 +3,12 @@ object PluginCoordinates {
     const val GROUP = "com.doist.gradle"
     const val VERSION = "0.0.4"
     const val IMPLEMENTATION_CLASS = "com.doist.gradle.changelog.ChangelogPlugin"
+    const val DESCRIPTION = "Gradle plugin to manage changelog."
+    const val DISPLAY_NAME = "Changelog plugin"
+    val TAGS = setOf("changelog")
 }
 
 object PluginBundle {
     const val VCS = "https://github.com/Doist/changelog-gradle-plugin"
     const val WEBSITE = "https://github.com/Doist/changelog-gradle-plugin"
-    const val DESCRIPTION = "Gradle plugin to manage changelog."
-    const val DISPLAY_NAME = "Changelog plugin"
-    val TAGS = listOf("changelog")
 }

--- a/buildSrc/src/main/java/Coordinates.kt
+++ b/buildSrc/src/main/java/Coordinates.kt
@@ -1,7 +1,7 @@
 object PluginCoordinates {
     const val ID = "com.doist.gradle.changelog"
     const val GROUP = "com.doist.gradle"
-    const val VERSION = "0.0.4"
+    const val VERSION = "0.1.0"
     const val IMPLEMENTATION_CLASS = "com.doist.gradle.changelog.ChangelogPlugin"
     const val DESCRIPTION = "Gradle plugin to manage changelog."
     const val DISPLAY_NAME = "Changelog plugin"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,14 +1,14 @@
 object Versions {
-    const val JUNIT = "4.13.1"
+    const val JUNIT = "4.13.2"
     const val KTLINT = "0.39.0"
 }
 
 object BuildPluginsVersion {
     const val DETEKT = "1.14.2"
-    const val KOTLIN = "1.3.72"
-    const val KTLINT = "9.4.1"
-    const val PLUGIN_PUBLISH = "0.12.0"
-    const val VERSIONS_PLUGIN = "0.33.0"
+    const val KOTLIN = "1.8.10"
+    const val KTLINT = "11.2.0"
+    const val PLUGIN_PUBLISH = "1.1.0"
+    const val VERSIONS_PLUGIN = "0.46.0"
 }
 
 object TestingLib {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/doist/gradle/changelog/ChangelogCheckTask.kt
+++ b/src/main/kotlin/com/doist/gradle/changelog/ChangelogCheckTask.kt
@@ -5,6 +5,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.VerificationTask
 import org.gradle.kotlin.dsl.listProperty
@@ -16,7 +17,7 @@ abstract class ChangelogCheckTask : DefaultTask(), VerificationTask {
         group = "changelog"
     }
 
-    @get:Input
+    @get:InputDirectory
     val pendingChangelogDir: DirectoryProperty = project.objects.directoryProperty()
 
     @get:Input

--- a/src/main/kotlin/com/doist/gradle/changelog/ChangelogCommitTask.kt
+++ b/src/main/kotlin/com/doist/gradle/changelog/ChangelogCommitTask.kt
@@ -7,6 +7,7 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.VerificationTask
@@ -20,7 +21,7 @@ abstract class ChangelogCommitTask : DefaultTask(), VerificationTask {
         group = "changelog"
     }
 
-    @get:Input
+    @get:InputDirectory
     val pendingChangelogDir: DirectoryProperty = project.objects.directoryProperty()
 
     @get:Input


### PR DESCRIPTION
## 🚀 Description
This PR updates the plugin's dependencies given they were becoming quite outdated. 
It also updates some property annotations from `@get:Input` to `@get:InputDirectory` because when trying to update consumers of this plugin to _gradle 8_, we're getting an error due to this:
<img width="1538" alt="Screenshot 2023-02-28 at 15 17 35" src="https://user-images.githubusercontent.com/8170256/221897598-e2acf381-a48e-4c4f-8cde-ddc9082b07d7.png">


## 📄 Motivation and Context
The main issue I wanted to address was the second commit, as when updating our projects to gradle 8, running the `checkChangelog` task was failing with the error above.
Then I noticed that dependencies were quite outdated so I took the chance to update them as well.

## 🧪 How Has This Been Tested?
All unit tests are passing.

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
