### PR TITLE
Bump GitHub Action pins to node24-compatible majors

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -14,6 +14,6 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout latest code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Validate Gradle Wrapper
         uses: gradle/actions/wrapper-validation@v4

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -18,19 +18,19 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '11'
       - name: Cache Gradle Caches
-        uses: actions/cache@v1
+        uses: actions/cache@v5
         with:
           path: ~/.gradle/caches/
           key: cache-gradle-cache
       - name: Cache Gradle Wrapper
-        uses: actions/cache@v1
+        uses: actions/cache@v5
         with:
           path: ~/.gradle/wrapper/
           key: cache-gradle-wrapper

--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -15,14 +15,14 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Cache Gradle Caches
-        uses: actions/cache@v1
+        uses: actions/cache@v5
         with:
           path: ~/.gradle/caches/
           key: cache-gradle-cache
       - name: Cache Gradle Wrapper
-        uses: actions/cache@v1
+        uses: actions/cache@v5
         with:
           path: ~/.gradle/wrapper/
           key: cache-gradle-wrapper


### PR DESCRIPTION
Bumps GitHub Action pins to majors that ship with the node24 runtime, ahead of GitHub's node20 deprecation.

- `actions/checkout` v4 → v6

Tracking: https://github.com/Doist/platform-backlog/issues/1385
